### PR TITLE
Panel Navigation

### DIFF
--- a/config/filament-types.php
+++ b/config/filament-types.php
@@ -16,11 +16,14 @@ return [
     'types_resource' => null,
 
     /**
-     * Show Navigation Menu
-     *
-     * If you need to show the navigation menu for the types
+     * Panel Navigation
+     * Accepts: boolean OR array of panel ID with boolean
+     * If array is empty, assumes to not display navigation item.
+     * 
+     * Panel Example:
+     *  'panel_navigation' => ['admin' => TRUE];
      */
-    'show_navigation' => true,
+    'panel_navigation' => true,
 
     /**
      * Empty State

--- a/src/Filament/Resources/TypeResource.php
+++ b/src/Filament/Resources/TypeResource.php
@@ -43,6 +43,29 @@ class TypeResource extends Resource
         return trans('filament-types::messages.group');
     }
 
+    /**
+     * Config Item: `panel_navigation`
+     * Returns: bool
+     * 
+     * Accepts: array OR bool
+     * 
+     * Compares against current panel ID based on what is in the array (if provided).
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        $configItem = config('filament-types.panel_navigation', TRUE);
+
+        if (is_array($configItem) && !empty($configItem)) {
+            foreach (config('filament-types.panel_navigation', true) as $key => $val) {
+                if (Filament::getCurrentPanel()->getId() === $key) {
+                    return $val;
+                }
+            }
+        } else {
+            return (empty($configItem)) ? FALSE : $configItem;
+        }
+    }
+
     public static function form(Form $form): Form
     {
         return TypeForm::make($form);


### PR DESCRIPTION
The current config item of "show_navigation" does not currently function (at least not that I could tell) - further, it does not take into consideration multiple panels.

This PR will add the functionaility to allow to control whether or not the navigation item is visible for multiple panels based on the panel ID.