### PR TITLE
Fix `locals` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ FilamentTypes::register([
 ]);
 ```
 
+## Config Locales
+
+You can change the locals within the `filament-types` config.
+
+- Publish the config file/
+- Modify the `locals` array to include the two character language code that applys to the language you wish to offer. EG:
+
+```
+'locals' = ['en'],
+```
+
 ## Use Type Helper
 
 you can find any type with the helper method to use it anywhere
@@ -112,7 +123,7 @@ TypeColumn::make('type')
     ->searchable(),
 ```
 
-## Auto Caching 
+## Auto Caching
 
 on your `.env` add this
 
@@ -181,7 +192,7 @@ class NotesGroups extends BaseTypePage
 }
 ```
 
-it will be not appear on the navigation menu by default but you can change that by just use this method 
+it will be not appear on the navigation menu by default but you can change that by just use this method
 
 ```php
 public static function shouldRegisterNavigation(): bool
@@ -195,7 +206,7 @@ public static function shouldRegisterNavigation(): bool
 if you like to use a type as a package we create a blade component for you to make it easy to use anywhere on your app like this
 
 ```html
-<x-tomato-type :type="$type" label="Group"/>
+<x-tomato-type :type="$type" label="Group" />
 ```
 
 ## User Types Resource Hooks
@@ -277,7 +288,7 @@ public function boot()
     ManagePageActions::register([
         Filament\Actions\Action::make('action')
     ]);
- 
+
 }
 ```
 
@@ -330,7 +341,6 @@ if you like to check the code by `PHPStan` just use this command
 ```bash
 composer analyse
 ```
-
 
 ## Other Filament Packages
 

--- a/config/filament-types.php
+++ b/config/filament-types.php
@@ -36,15 +36,11 @@ return [
      * Locals
      *
      * If you need to use locals for the types you can set it here
+     * 
+     * EG: ['en','ar'] will provide English and Arabic options.
+     * 
+     * Default: NULL, provides English and Arabic options.
      */
-    'locals' => [
-        'ar' => [
-            'ar' => 'العربية',
-            'en' => 'Arabic',
-        ],
-        'en' => [
-            'ar' => 'الإنجليزية',
-            'en' => 'English',
-        ],
-    ],
+
+    'locals' => NULL,
 ];

--- a/src/FilamentTypesPlugin.php
+++ b/src/FilamentTypesPlugin.php
@@ -16,16 +16,14 @@ class FilamentTypesPlugin implements Plugin
     /**
      * @return $this
      */
-    public function locals(array $locals): self
+    public function locals()
     {
-        self::$locals = $locals;
-
-        return $this;
+        return (!is_null(config('filament-types.locals'))) ? config('filament-types.locals') : $this->locals;
     }
 
     public function getLocals(): array
     {
-        return self::$locals;
+        return $this->locals();
     }
 
     /**

--- a/src/FilamentTypesPlugin.php
+++ b/src/FilamentTypesPlugin.php
@@ -9,7 +9,7 @@ use TomatoPHP\FilamentTypes\Filament\Resources\TypeResource;
 
 class FilamentTypesPlugin implements Plugin
 {
-    protected static array $locals = ['ar', 'en'];
+    protected array $locals = ['ar', 'en'];
 
     protected static array $types = [];
 


### PR DESCRIPTION
In the current build the "locals" config item does nothing.

This PR fixes that functionality so that one can dynamically assign the preferred locales.

Changes the default config item to: `NULL` so as to maintain the existing options of "Arabic, English" but one can change it simply to an array of `['en']` or others to change those options out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new section "Config Locales" in the README for localization instructions.
	- Updated the "Auto Caching" section for clarity and added supported cache stores.
	- Revised the "Use Type Component" section for improved formatting.

- **Configuration Changes**
	- Updated the 'locals' setting in the configuration to be `NULL`, clarifying language options.

- **Functionality Updates**
	- Modified the `locals` method to retrieve localization settings dynamically rather than through a parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->