### PR TITLE
Fix PSR-4 not compatible error

### DIFF
--- a/src/Filament/Resources/TypeResource/Table/Columns/Id.php
+++ b/src/Filament/Resources/TypeResource/Table/Columns/Id.php
@@ -4,7 +4,7 @@ namespace TomatoPHP\FilamentTypes\Filament\Resources\TypeResource\Table\Columns;
 
 use Filament\Tables;
 
-class ID extends Column
+class Id extends Column
 {
     public static function make(): Tables\Columns\TextColumn
     {


### PR DESCRIPTION
This fixed "Class TomatoPHP\FilamentTypes\Filament\Resources\TypeResource\Table\Columns\ID located in ./vendor/tomatophp/filament-types/src/Filament/Resources/TypeResource/Table/Columns/Id.php does not comply with psr-4 autoloading standard. Skipping."
<img width="1553" height="153" alt="image" src="https://github.com/user-attachments/assets/6df17a20-f7af-4a3a-ba40-76bd6a6516f1" />
